### PR TITLE
Fix emulation of Zoloto spherical coordinates

### DIFF
--- a/april_vision/__init__.py
+++ b/april_vision/__init__.py
@@ -3,8 +3,9 @@ from ._version import __version__
 from .calibrations import calibrations
 from .detect_cameras import find_cameras
 from .frame_sources import FrameSource, USBCamera
-from .marker import (CartesianCoordinates, Marker, Orientation,
-                     PixelCoordinates, SphericalCoordinate)
+from .marker import (CartesianCoordinates, Marker,
+                     MathematicalSphericalCoordinate, Orientation,
+                     PixelCoordinates, SphericalCoordinates)
 from .vision import Processor
 
 __all__ = [
@@ -12,10 +13,11 @@ __all__ = [
     'CartesianCoordinates',
     'FrameSource',
     'Marker',
+    'MathematicalSphericalCoordinate',
     'Orientation',
     'PixelCoordinates',
     'Processor',
-    'SphericalCoordinate',
+    'SphericalCoordinates',
     'USBCamera',
     'calibrations',
     'find_cameras',


### PR DESCRIPTION
This fixes a bug where the unpacking of the spherical coordinates in Zoloto legacy mode was not actually compatible with Zoloto due to the order of the tuple members having changed and the name of one of the members had changed.

To preserve the new-style behaviour we break that out into its own type with unchanged behaviour. The Zoloto emulation is replaced by a copy of the logic which Zoloto itself used, slightly altered to support the renamed member in both spellings.

The name of the (legacy) type is also changed here for consistency with the other types names (it's now plural).

Fixes https://github.com/WillB97/april_vision/issues/8