### PR TITLE
Default aruco orientation to false

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 PYMODULE:=april_vision
 TESTS:=tests
 
-all: lint isort-check type build
+all: lint isort-check type test
 
 lint:
 	flake8 $(PYMODULE)

--- a/april_vision/cli/annotate_image.py
+++ b/april_vision/cli/annotate_image.py
@@ -99,6 +99,6 @@ def create_subparser(subparsers: argparse._SubParsersAction) -> None:
     parser.add_argument(
         '--tag_size', type=int, default=0, help="The size of markers in millimeters")
     parser.add_argument(
-        '--aruco-orientation', action='store_true', help="Use ArUco marker orientation.")
+        '--aruco_orientation', action='store_true', help="Use ArUco marker orientation.")
 
     parser.set_defaults(func=main)

--- a/april_vision/cli/annotate_image.py
+++ b/april_vision/cli/annotate_image.py
@@ -35,6 +35,7 @@ def main(args: argparse.Namespace) -> None:
         quad_decimate=args.quad_decimate,
         tag_sizes=float(args.tag_size) / 1000,
         calibration=calibration,
+        aruco_orientation=args.aruco_orientation,
     )
 
     frame = processer._capture()
@@ -97,5 +98,7 @@ def create_subparser(subparsers: argparse._SubParsersAction) -> None:
         '--calibration', type=Path, default=None, help="Calbration XML file to use.")
     parser.add_argument(
         '--tag_size', type=int, default=0, help="The size of markers in millimeters")
+    parser.add_argument(
+        '--aruco-orientation', action='store_true', help="Use ArUco marker orientation.")
 
     parser.set_defaults(func=main)

--- a/april_vision/cli/annotate_video.py
+++ b/april_vision/cli/annotate_video.py
@@ -41,6 +41,7 @@ def main(args: argparse.Namespace) -> None:
         quad_decimate=args.quad_decimate,
         tag_sizes=float(args.tag_size) / 1000,
         calibration=calibration,
+        aruco_orientation=args.aruco_orientation,
     )
     output = cv2.VideoWriter(
         args.output_file, cv2.VideoWriter.fourcc(*'mp4v'), fps, (width, height))
@@ -114,5 +115,7 @@ def create_subparser(subparsers: argparse._SubParsersAction) -> None:
         '--calibration', type=Path, default=None, help="Calbration XML file to use.")
     parser.add_argument(
         '--tag_size', type=int, default=0, help="The size of markers in millimeters")
+    parser.add_argument(
+        '--aruco-orientation', action='store_true', help="Use ArUco marker orientation.")
 
     parser.set_defaults(func=main)

--- a/april_vision/cli/annotate_video.py
+++ b/april_vision/cli/annotate_video.py
@@ -116,6 +116,6 @@ def create_subparser(subparsers: argparse._SubParsersAction) -> None:
     parser.add_argument(
         '--tag_size', type=int, default=0, help="The size of markers in millimeters")
     parser.add_argument(
-        '--aruco-orientation', action='store_true', help="Use ArUco marker orientation.")
+        '--aruco_orientation', action='store_true', help="Use ArUco marker orientation.")
 
     parser.set_defaults(func=main)

--- a/april_vision/cli/live.py
+++ b/april_vision/cli/live.py
@@ -70,6 +70,7 @@ def main(args: argparse.Namespace) -> None:
         quad_decimate=args.quad_decimate,
         tag_sizes=float(args.tag_size) / 1000,
         calibration=source.calibration,
+        aruco_orientation=args.aruco_orientation,
     )
 
     LOGGER.info("Press S to save image, press Q to exit")
@@ -186,6 +187,8 @@ def create_subparser(subparsers: argparse._SubParsersAction) -> None:
         '--tag_family', default=MarkerType.APRILTAG_36H11.value,
         choices=[marker.value for marker in MarkerType],
         help="Set the marker family to detect, defaults to 'tag36h11'")
+    parser.add_argument(
+        '--aruco_orientation', action='store_true', help="Use ArUco marker orientation.")
     parser.add_argument(
         '--quad_decimate', type=float, default=2,
         help="Set the level of decimation used in the detection stage")

--- a/april_vision/helpers/sender.py
+++ b/april_vision/helpers/sender.py
@@ -27,7 +27,7 @@ class Base64Sender:
         *,
         annotated: bool = True,
         threaded: bool = True,
-        aruco_orientation: bool = True,
+        aruco_orientation: bool = False,
     ):
         self._publish_callback = publish_callback
         self.use_threads = threaded

--- a/april_vision/marker.py
+++ b/april_vision/marker.py
@@ -160,7 +160,7 @@ class Orientation(NamedTuple):
     def from_rvec_matrix(
         cls,
         rotation_matrix: NDArray,
-        aruco_orientation: bool = True
+        aruco_orientation: bool = False,
     ) -> 'Orientation':
         """
         Calculate yaw, pitch, roll given the rotation matrix in the camera's coordinate system.
@@ -177,7 +177,7 @@ class Orientation(NamedTuple):
     def from_quaternion(
         cls,
         quaternion: Quaternion,
-        aruco_orientation: bool = True
+        aruco_orientation: bool = False,
     ) -> 'Orientation':
         """
         Calculate yaw, pitch, roll given the quaternion in the camera's coordinate system.
@@ -272,14 +272,14 @@ class Marker(NamedTuple):
     spherical: SphericalCoordinate = SphericalCoordinate(0, 0, 0)
     orientation: Orientation = Orientation(0, 0, 0)
 
-    aruco_orientation: bool = True
+    aruco_orientation: bool = False
 
     @classmethod
     def from_detection(
         cls,
         marker: Detection,
         *,
-        aruco_orientation: bool = True,
+        aruco_orientation: bool = False,
     ) -> 'Marker':
         _tag_size = int((marker.tag_size or 0) * 1000)
 

--- a/april_vision/vision.py
+++ b/april_vision/vision.py
@@ -31,7 +31,7 @@ class Processor:
         tag_family: str = 'tag36h11',
         threads: int = 4,
         quad_decimate: float = 2,
-        aruco_orientation: bool = True,
+        aruco_orientation: bool = False,
         name: str = "Camera",
         vidpid: str = "",
         mask_unknown_size_tags: bool = False,

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -17,7 +17,7 @@ CALIBRATION = [
 
 @pytest.fixture
 def processor():
-    yield Processor(calibration=CALIBRATION, tag_sizes=0.2, aruco_orientation=False)
+    yield Processor(calibration=CALIBRATION, tag_sizes=0.2)
 
 
 class MarkerValues(NamedTuple):


### PR DESCRIPTION
AprilTag orientation detection using OpenCV's AruCo library inverts the marker, leading to a 180° offset in roll values. The original version of the `april_vision` library defaulted to correcting for using markers generated for AruCo to facilitate a smooth transition from the `zoloto` library.

This switches to defaulting to using actual AprilTag orientation to allow correct values when using regular AprilTag markers.