### PR TITLE
Detect and report serial numbers for USB cameras

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ cameras = setup_cameras(tag_sizes)
 if len(cameras) == 0:
     print("No cameras found")
 
-for name, cam in cameras.items():
-    print(name)
+for serial, cam in cameras.items():
+    print(cam.model, serial)
     print(cam.see())
 ```
 

--- a/april_vision/cli/live.py
+++ b/april_vision/cli/live.py
@@ -46,31 +46,55 @@ def main(args: argparse.Namespace) -> None:
 
     camera_properties = parse_properties(args)
 
-    if args.id is None:
-        cameras = find_cameras(calibrations, include_uncalibrated=True)
+    cameras = find_cameras(calibrations, include_uncalibrated=True)
+    if args.serial is not None:
+        cameras_dict = {camera.serial_num: camera for camera in cameras if camera.serial_num}
+        try:
+            camera = cameras_dict[args.serial]
+        except KeyError:
+            LOGGER.fatal(f"Camera with serial {args.serial} not found")
+            return
+    elif args.id is not None:
+        cameras_dict = {camera.index: camera for camera in cameras}
+        try:
+            camera = cameras_dict[args.id]
+        except KeyError:
+            LOGGER.fatal(f"Camera with index {args.id} not found")
+            return
+    else:
         try:
             camera = cameras[0]
         except IndexError:
             LOGGER.fatal("No cameras found")
             return
-        source = USBCamera.from_calibration_file(
-            camera.index,
-            camera.calibration,
-            camera.vidpid,
-            camera_parameters=camera_properties,
-        )
-    else:
+
+    # Allow the user to override the camera index.
+    # This is useful on MacOS where the camera index is not always
+    # correct
+    index = args.id if args.id is not None else camera.index
+
+    if camera.calibration is None:
         if args.set_resolution is not None:
             resolution_raw = args.set_resolution.split('x')
             resolution = (int(resolution_raw[0]), int(resolution_raw[1]))
         else:
             resolution = (1280, 720)
+
         source = USBCamera(
-            args.id,
+            index,
             resolution,
             camera_parameters=camera_properties,
         )
-        print(f"Resolution set to {source._get_resolution()}")
+    else:
+        source = USBCamera.from_calibration_file(
+            index,
+            camera.calibration,
+            camera.vidpid,
+            camera_parameters=camera_properties,
+        )
+    LOGGER.info(f"Camera {camera.name} ({camera.serial_num}) opened, index {index}")
+    LOGGER.info(f"Resolution set to {source._get_resolution()}")
+
     cam = Processor(
         source,
         tag_family=args.tag_family,
@@ -181,6 +205,9 @@ def create_subparser(subparsers: argparse._SubParsersAction) -> None:
         help="Live camera demonstration with marker annotation.",
     )
 
+    parser.add_argument(
+        "--serial", type=str, default=None,
+        help="Select the camera by serial number.")
     parser.add_argument(
         "--id", type=int, default=None, help="Override the camera index to use.")
     parser.add_argument(

--- a/april_vision/cli/live.py
+++ b/april_vision/cli/live.py
@@ -60,11 +60,17 @@ def main(args: argparse.Namespace) -> None:
             camera_parameters=camera_properties,
         )
     else:
+        if args.set_resolution is not None:
+            resolution_raw = args.set_resolution.split('x')
+            resolution = (int(resolution_raw[0]), int(resolution_raw[1]))
+        else:
+            resolution = (1280, 720)
         source = USBCamera(
             args.id,
-            (1280, 720),
+            resolution,
             camera_parameters=camera_properties,
         )
+        print(f"Resolution set to {source._get_resolution()}")
     cam = Processor(
         source,
         tag_family=args.tag_family,
@@ -211,6 +217,12 @@ def create_subparser(subparsers: argparse._SubParsersAction) -> None:
         type=str,
         default=None,
         help="4-character code of codec to set camera to (e.g. MJPG)"
+    )
+    parser.add_argument(
+        '--set_resolution',
+        type=str,
+        default=None,
+        help="The resolution to use for a manually specified camera (e.g. 1280x720)"
     )
 
     parser.set_defaults(func=main)

--- a/april_vision/cli/live.py
+++ b/april_vision/cli/live.py
@@ -48,9 +48,12 @@ def main(args: argparse.Namespace) -> None:
 
     cameras = find_cameras(calibrations, include_uncalibrated=True)
     if args.serial is not None:
-        cameras_dict = {camera.serial_num: camera for camera in cameras if camera.serial_num}
+        cameras_serial_dict = {
+            camera.serial_num: camera
+            for camera in cameras if camera.serial_num
+        }
         try:
-            camera = cameras_dict[args.serial]
+            camera = cameras_serial_dict[args.serial]
         except KeyError:
             LOGGER.fatal(f"Camera with serial {args.serial} not found")
             return

--- a/april_vision/detect_cameras.py
+++ b/april_vision/detect_cameras.py
@@ -317,8 +317,8 @@ def windows_discovery() -> List[CameraIdentifier]:
     assert sys.platform == 'win32', "This method is only for Windows"
 
     import winrt.windows.devices.enumeration as windows_devices  # type: ignore[import-not-found,unused-ignore]
-    from winrt.windows.foundation import (
-        IPropertyValue,  # type: ignore[import-not-found,unused-ignore]
+    from winrt.windows.foundation import (  # type: ignore[import-not-found,unused-ignore]
+        IPropertyValue,
     )
 
     async def get_parent_id(device_container):  # type: ignore

--- a/april_vision/detect_cameras.py
+++ b/april_vision/detect_cameras.py
@@ -18,6 +18,7 @@ class CameraIdentifier(NamedTuple):
     index: int  # type: ignore[assignment]
     name: str
     vidpid: str
+    serial_num: Optional[str] = None
 
 
 class CalibratedCamera(NamedTuple):
@@ -26,6 +27,7 @@ class CalibratedCamera(NamedTuple):
     index: int  # type: ignore[assignment]
     name: str
     vidpid: str
+    serial_num: Optional[str] = None
     calibration: Optional[Path] = None
 
 
@@ -100,6 +102,7 @@ def match_calibrations(
                 index=camera.index,
                 name=camera.name,
                 vidpid=camera.vidpid,
+                serial_num=camera.serial_num,
                 calibration=calibration_map[camera.vidpid],
             ))
             LOGGER.debug(
@@ -111,6 +114,7 @@ def match_calibrations(
                     index=camera.index,
                     name=camera.name,
                     vidpid=camera.vidpid,
+                    serial_num=camera.serial_num,
                 ))
 
     return calibrated_cameras + uncalibrated_cameras

--- a/april_vision/detect_cameras.py
+++ b/april_vision/detect_cameras.py
@@ -189,6 +189,10 @@ def mac_discovery() -> List[CameraIdentifier]:
         subprocess.check_output(['system_profiler', '-json', 'SPCameraDataType']),
     )
     camera_list = camera_info["SPCameraDataType"]
+    # Preserve devices ordering on the system
+    # see AVCaptureDevice::uniqueID property documentation for more info
+    # From https://github.com/opencv/opencv/blob/4.11.0/modules/videoio/src/cap_avfoundation_mac.mm#L377
+    camera_list.sort(key=lambda x: x["spcamera_unique-id"])
     cameras = []
 
     for index, camera in enumerate(camera_list):


### PR DESCRIPTION
Extends `april_vision live` to have a `--serial` option for selecting a camera by its serial number.

Also fixes MacOS camera indexing.